### PR TITLE
ignore url query strings in file path

### DIFF
--- a/index.js
+++ b/index.js
@@ -212,7 +212,7 @@ function defaultRevision(url) {
 }
 
 function defaultFile(url) {
-  return decodeURIComponent(url.substring(url.indexOf("/", 1) + 1));
+  return decodeURIComponent(url.substring(url.indexOf("/", 1) + 1)).split("?")[0];
 }
 
 function defaultType(file) {


### PR DESCRIPTION
URL Query strings are included in the file path causing "file not found" errors. This should workaround that. Nothing fancy, just a split on the first `?` encountered in the file path.